### PR TITLE
 Allow using IComparable<T> as BinarySearch argument 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Allow using `IComparable<T>` as `BinarySearch` argument
 
 ## [1.12.0] - 2022-03-25
 ### Changed

--- a/Source/AtCoderLibrary/STL/Extension/BinarySearch.List.cs
+++ b/Source/AtCoderLibrary/STL/Extension/BinarySearch.List.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace AtCoder.Extension
+{
+    public static class BinarySearchListExtension
+    {
+        private struct DefaultComparer<T> : IComparer<T> where T : IComparable<T>
+        {
+            [MethodImpl(256)]
+            public int Compare(T x, T y) => x.CompareTo(y);
+        }
+        private interface IOk
+        {
+            bool Ok(int c);
+        }
+        private struct L : IOk
+        {
+            [MethodImpl(256)]
+            public bool Ok(int c) => c >= 0;
+        }
+        private struct U : IOk
+        {
+            [MethodImpl(256)]
+            public bool Ok(int c) => c > 0;
+        }
+
+        /// <summary>
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: <paramref name="a"/> がソート済み</para>
+        /// <para>計算量: O(n)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static int LowerBound<T>(this IList<T> a, T v) where T : IComparable<T>
+            => LowerBound(a, v, default(DefaultComparer<T>));
+        /// <summary>
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: <paramref name="a"/> がソート済み</para>
+        /// <para>計算量: O(n)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static int LowerBound<T, TOp>(this IList<T> a, T v, TOp cmp) where TOp : IComparer<T>
+            => BinarySearch<T, TOp, L>(a, v, cmp);
+        /// <summary>
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: <paramref name="a"/> がソート済み</para>
+        /// <para>計算量: O(n)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static int UpperBound<T>(this IList<T> a, T v) where T : IComparable<T>
+            => UpperBound(a, v, default(DefaultComparer<T>));
+        /// <summary>
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: <paramref name="a"/> がソート済み</para>
+        /// <para>計算量: O(n)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static int UpperBound<T, TOp>(this IList<T> a, T v, TOp cmp) where TOp : IComparer<T>
+            => BinarySearch<T, TOp, U>(a, v, cmp);
+        [MethodImpl(256)]
+        private static int BinarySearch<T, TOp, TOk>(this IList<T> a, T v, TOp cmp)
+            where TOp : IComparer<T>
+            where TOk : IOk
+        {
+            int ok = a.Count;
+            int ng = -1;
+            while (ok - ng > 1)
+            {
+                var m = (ok + ng) >> 1;
+                var c = cmp.Compare(a[m], v);
+                if (default(TOk).Ok(c)) ok = m;
+                else ng = m;
+            }
+            return ok;
+        }
+    }
+}

--- a/Source/AtCoderLibrary/STL/Extension/BinarySearch.List.cs
+++ b/Source/AtCoderLibrary/STL/Extension/BinarySearch.List.cs
@@ -6,36 +6,6 @@ namespace AtCoder.Extension
 {
     public static class BinarySearchListExtension
     {
-        private struct DefaultComparer<T> : IComparer<T> where T : IComparable<T>
-        {
-            [MethodImpl(256)]
-            public int Compare(T x, T y) => x.CompareTo(y);
-        }
-        private interface IOk
-        {
-            bool Ok(int c);
-        }
-        private struct L : IOk
-        {
-            [MethodImpl(256)]
-            public bool Ok(int c) => c >= 0;
-        }
-        private struct U : IOk
-        {
-            [MethodImpl(256)]
-            public bool Ok(int c) => c > 0;
-        }
-
-        /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: <paramref name="a"/> がソート済み</para>
-        /// <para>計算量: O(n)</para>
-        /// </remarks>
-        [MethodImpl(256)]
-        public static int LowerBound<T>(this IList<T> a, T v) where T : IComparable<T>
-            => LowerBound(a, v, default(DefaultComparer<T>));
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
         /// </summary>
@@ -45,17 +15,17 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int LowerBound<T, TOp>(this IList<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, L>(a, v, cmp);
+            => LowerBound(a, new CmpWrapper<T, TOp>(v, cmp));
         /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
         /// </summary>
         /// <remarks>
         /// <para>制約: <paramref name="a"/> がソート済み</para>
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int UpperBound<T>(this IList<T> a, T v) where T : IComparable<T>
-            => UpperBound(a, v, default(DefaultComparer<T>));
+        public static int LowerBound<T, TCv>(this IList<T> a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, L>(a, v);
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
         /// </summary>
@@ -65,10 +35,39 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int UpperBound<T, TOp>(this IList<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, U>(a, v, cmp);
+            => UpperBound(a, new CmpWrapper<T, TOp>(v, cmp));
+        /// <summary>
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: <paramref name="a"/> がソート済み</para>
+        /// <para>計算量: O(n)</para>
+        /// </remarks>
         [MethodImpl(256)]
-        private static int BinarySearch<T, TOp, TOk>(this IList<T> a, T v, TOp cmp)
-            where TOp : IComparer<T>
+        public static int UpperBound<T, TCv>(this IList<T> a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, U>(a, v);
+
+        private readonly struct CmpWrapper<T, TCmp> : IComparable<T>
+            where TCmp : IComparer<T>
+        {
+            readonly T v;
+            readonly TCmp cmp;
+            public CmpWrapper(T v, TCmp cmp)
+            {
+                this.v = v;
+                this.cmp = cmp;
+            }
+
+            [MethodImpl(256)]
+            public int CompareTo(T other) => cmp.Compare(v, other);
+        }
+        private interface IOk { bool Ok(int c); }
+        private struct L : IOk {[MethodImpl(256)] public bool Ok(int c) => c <= 0; }
+        private struct U : IOk {[MethodImpl(256)] public bool Ok(int c) => c < 0; }
+
+        [MethodImpl(256)]
+        private static int BinarySearch<T, TCv, TOk>(this IList<T> a, TCv v)
+            where TCv : IComparable<T>
             where TOk : IOk
         {
             int ok = a.Count;
@@ -76,7 +75,7 @@ namespace AtCoder.Extension
             while (ok - ng > 1)
             {
                 var m = (ok + ng) >> 1;
-                var c = cmp.Compare(a[m], v);
+                var c = v.CompareTo(a[m]);
                 if (default(TOk).Ok(c)) ok = m;
                 else ng = m;
             }

--- a/Source/AtCoderLibrary/STL/Extension/BinarySearch.Span.cs
+++ b/Source/AtCoderLibrary/STL/Extension/BinarySearch.Span.cs
@@ -6,25 +6,16 @@ namespace AtCoder.Extension
 {
     public static class BinarySearchExtension
     {
-        private struct DefaultComparer<T> : IComparer<T> where T : IComparable<T>
-        {
-            [MethodImpl(256)]
-            public int Compare(T x, T y) => x.CompareTo(y);
-        }
-        private interface IOk
-        {
-            bool Ok(int c);
-        }
-        private struct L : IOk
-        {
-            [MethodImpl(256)]
-            public bool Ok(int c) => c >= 0;
-        }
-        private struct U : IOk
-        {
-            [MethodImpl(256)]
-            public bool Ok(int c) => c > 0;
-        }
+        /// <summary>
+        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: <paramref name="a"/> がソート済み</para>
+        /// <para>計算量: O(n)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static int LowerBound<T, TCv>(this T[] a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, L>(a, v);
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
@@ -34,8 +25,8 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int LowerBound<T>(this T[] a, T v) where T : IComparable<T>
-            => LowerBound(a, v, default(DefaultComparer<T>));
+        public static int LowerBound<T, TCv>(this Span<T> a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, L>(a, v);
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
@@ -45,19 +36,8 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int LowerBound<T>(this Span<T> a, T v) where T : IComparable<T>
-            => LowerBound(a, v, default(DefaultComparer<T>));
-
-        /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: <paramref name="a"/> がソート済み</para>
-        /// <para>計算量: O(n)</para>
-        /// </remarks>
-        [MethodImpl(256)]
-        public static int LowerBound<T>(this ReadOnlySpan<T> a, T v) where T : IComparable<T>
-            => LowerBound(a, v, default(DefaultComparer<T>));
+        public static int LowerBound<T, TCv>(this ReadOnlySpan<T> a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, L>(a, v);
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
@@ -68,7 +48,7 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int LowerBound<T, TOp>(this T[] a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, L>(a.AsSpan(), v, cmp);
+            => LowerBound(a, new CmpWrapper<T, TOp>(v, cmp));
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
@@ -79,7 +59,7 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int LowerBound<T, TOp>(this Span<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, L>(a, v, cmp);
+            => LowerBound(a, new CmpWrapper<T, TOp>(v, cmp));
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
@@ -90,7 +70,7 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int LowerBound<T, TOp>(this ReadOnlySpan<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, L>(a, v, cmp);
+            => LowerBound(a, new CmpWrapper<T, TOp>(v, cmp));
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -100,8 +80,8 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int UpperBound<T>(this T[] a, T v) where T : IComparable<T>
-            => UpperBound(a.AsSpan(), v, default(DefaultComparer<T>));
+        public static int UpperBound<T, TCv>(this T[] a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, U>(a, v);
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -111,8 +91,8 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int UpperBound<T>(this Span<T> a, T v) where T : IComparable<T>
-            => UpperBound(a, v, default(DefaultComparer<T>));
+        public static int UpperBound<T, TCv>(this Span<T> a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, U>(a, v);
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -122,8 +102,8 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int UpperBound<T>(this ReadOnlySpan<T> a, T v) where T : IComparable<T>
-            => UpperBound(a, v, default(DefaultComparer<T>));
+        public static int UpperBound<T, TCv>(this ReadOnlySpan<T> a, TCv v) where TCv : IComparable<T>
+            => BinarySearch<T, TCv, U>(a, v);
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -134,7 +114,7 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int UpperBound<T, TOp>(this T[] a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, U>(a.AsSpan(), v, cmp);
+            => UpperBound(a, new CmpWrapper<T, TOp>(v, cmp));
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -145,7 +125,7 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int UpperBound<T, TOp>(this Span<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, U>(a, v, cmp);
+            => UpperBound(a, new CmpWrapper<T, TOp>(v, cmp));
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -156,20 +136,36 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int UpperBound<T, TOp>(this ReadOnlySpan<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, U>(a, v, cmp);
+            => UpperBound(a, new CmpWrapper<T, TOp>(v, cmp));
 
+        private readonly struct CmpWrapper<T, TCmp> : IComparable<T>
+            where TCmp : IComparer<T>
+        {
+            readonly T v;
+            readonly TCmp cmp;
+            public CmpWrapper(T v, TCmp cmp)
+            {
+                this.v = v;
+                this.cmp = cmp;
+            }
+
+            [MethodImpl(256)]
+            public int CompareTo(T other) => cmp.Compare(v, other);
+        }
+        private interface IOk { bool Ok(int c); }
+        private struct L : IOk {[MethodImpl(256)] public bool Ok(int c) => c <= 0; }
+        private struct U : IOk {[MethodImpl(256)] public bool Ok(int c) => c < 0; }
         [MethodImpl(256)]
-        private static int BinarySearch<T, TOp, TOk>(this ReadOnlySpan<T> a, T v, TOp cmp)
-            where TOp : IComparer<T>
+        private static int BinarySearch<T, TCv, TOk>(this ReadOnlySpan<T> a, TCv v)
+            where TCv : IComparable<T>
             where TOk : IOk
-
         {
             int ok = a.Length;
             int ng = -1;
             while (ok - ng > 1)
             {
                 var m = (ok + ng) >> 1;
-                var c = cmp.Compare(a[m], v);
+                var c = v.CompareTo(a[m]);
                 if (default(TOk).Ok(c)) ok = m;
                 else ng = m;
             }

--- a/Source/AtCoderLibrary/STL/Extension/BinarySearch.Span.cs
+++ b/Source/AtCoderLibrary/STL/Extension/BinarySearch.Span.cs
@@ -35,17 +35,6 @@ namespace AtCoder.Extension
         /// </remarks>
         [MethodImpl(256)]
         public static int LowerBound<T>(this T[] a, T v) where T : IComparable<T>
-            => LowerBound(a.AsSpan(), v, default(DefaultComparer<T>));
-
-        /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: <paramref name="a"/> がソート済み</para>
-        /// <para>計算量: O(n)</para>
-        /// </remarks>
-        [MethodImpl(256)]
-        public static int LowerBound<T>(this IList<T> a, T v) where T : IComparable<T>
             => LowerBound(a, v, default(DefaultComparer<T>));
 
         /// <summary>
@@ -89,17 +78,6 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int LowerBound<T, TOp>(this IList<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, L>(a, v, cmp);
-
-        /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> 以上の値が現れる最小のインデックスを取得します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: <paramref name="a"/> がソート済み</para>
-        /// <para>計算量: O(n)</para>
-        /// </remarks>
-        [MethodImpl(256)]
         public static int LowerBound<T, TOp>(this Span<T> a, T v, TOp cmp) where TOp : IComparer<T>
             => BinarySearch<T, TOp, L>(a, v, cmp);
 
@@ -124,17 +102,6 @@ namespace AtCoder.Extension
         [MethodImpl(256)]
         public static int UpperBound<T>(this T[] a, T v) where T : IComparable<T>
             => UpperBound(a.AsSpan(), v, default(DefaultComparer<T>));
-
-        /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: <paramref name="a"/> がソート済み</para>
-        /// <para>計算量: O(n)</para>
-        /// </remarks>
-        [MethodImpl(256)]
-        public static int UpperBound<T>(this IList<T> a, T v) where T : IComparable<T>
-            => UpperBound(a, v, default(DefaultComparer<T>));
 
         /// <summary>
         /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
@@ -177,17 +144,6 @@ namespace AtCoder.Extension
         /// <para>計算量: O(n)</para>
         /// </remarks>
         [MethodImpl(256)]
-        public static int UpperBound<T, TOp>(this IList<T> a, T v, TOp cmp) where TOp : IComparer<T>
-            => BinarySearch<T, TOp, U>(a, v, cmp);
-
-        /// <summary>
-        /// <paramref name="a"/> の要素のうち、<paramref name="v"/> より大きい値が現れる最小のインデックスを取得します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: <paramref name="a"/> がソート済み</para>
-        /// <para>計算量: O(n)</para>
-        /// </remarks>
-        [MethodImpl(256)]
         public static int UpperBound<T, TOp>(this Span<T> a, T v, TOp cmp) where TOp : IComparer<T>
             => BinarySearch<T, TOp, U>(a, v, cmp);
 
@@ -202,22 +158,6 @@ namespace AtCoder.Extension
         public static int UpperBound<T, TOp>(this ReadOnlySpan<T> a, T v, TOp cmp) where TOp : IComparer<T>
             => BinarySearch<T, TOp, U>(a, v, cmp);
 
-        [MethodImpl(256)]
-        private static int BinarySearch<T, TOp, TOk>(this IList<T> a, T v, TOp cmp)
-            where TOp : IComparer<T>
-            where TOk : IOk
-        {
-            int ok = a.Count;
-            int ng = -1;
-            while (ok - ng > 1)
-            {
-                var m = (ok + ng) >> 1;
-                var c = cmp.Compare(a[m], v);
-                if (default(TOk).Ok(c)) ok = m;
-                else ng = m;
-            }
-            return ok;
-        }
         [MethodImpl(256)]
         private static int BinarySearch<T, TOp, TOk>(this ReadOnlySpan<T> a, T v, TOp cmp)
             where TOp : IComparer<T>

--- a/Test/AtCoderLibrary.Test/STL/BinarySearchTest.cs
+++ b/Test/AtCoderLibrary.Test/STL/BinarySearchTest.cs
@@ -8,7 +8,6 @@ namespace AtCoder.Extension
 {
     public class BinarySearchTest
     {
-
         [Fact]
         public void Simple()
         {
@@ -129,6 +128,70 @@ namespace AtCoder.Extension
             ((IList<int>)arr).UpperBound(-1, ComparerUtil.ReverseComparerInt).Should().Be(11);
             ((Span<int>)arr).UpperBound(-1, ComparerUtil.ReverseComparerInt).Should().Be(11);
             ((ReadOnlySpan<int>)arr).UpperBound(-1, ComparerUtil.ReverseComparerInt).Should().Be(11);
+        }
+
+        [Fact]
+        public void Comparable()
+        {
+            var arr = new int[] { 0, 1, 2, 3, 3, 3, 6, 7, 8, 9, 100 };
+
+            arr.LowerBound(new ArrayLengthComparable(0)).Should().Be(0);
+            ((IList<int>)arr).LowerBound(new ArrayLengthComparable(0)).Should().Be(0);
+            ((Span<int>)arr).LowerBound(new ArrayLengthComparable(0)).Should().Be(0);
+            ((ReadOnlySpan<int>)arr).LowerBound(new ArrayLengthComparable(0)).Should().Be(0);
+
+            arr.UpperBound(new ArrayLengthComparable(0)).Should().Be(1);
+            ((IList<int>)arr).UpperBound(new ArrayLengthComparable(0)).Should().Be(1);
+            ((Span<int>)arr).UpperBound(new ArrayLengthComparable(0)).Should().Be(1);
+            ((ReadOnlySpan<int>)arr).UpperBound(new ArrayLengthComparable(0)).Should().Be(1);
+
+            arr.LowerBound(new ArrayLengthComparable(3)).Should().Be(3);
+            ((IList<int>)arr).LowerBound(new ArrayLengthComparable(3)).Should().Be(3);
+            ((Span<int>)arr).LowerBound(new ArrayLengthComparable(3)).Should().Be(3);
+            ((ReadOnlySpan<int>)arr).LowerBound(new ArrayLengthComparable(3)).Should().Be(3);
+
+            arr.UpperBound(new ArrayLengthComparable(3)).Should().Be(6);
+            ((IList<int>)arr).UpperBound(new ArrayLengthComparable(3)).Should().Be(6);
+            ((Span<int>)arr).UpperBound(new ArrayLengthComparable(3)).Should().Be(6);
+            ((ReadOnlySpan<int>)arr).UpperBound(new ArrayLengthComparable(3)).Should().Be(6);
+
+            arr.LowerBound(new ArrayLengthComparable(10)).Should().Be(10);
+            ((IList<int>)arr).LowerBound(new ArrayLengthComparable(10)).Should().Be(10);
+            ((Span<int>)arr).LowerBound(new ArrayLengthComparable(10)).Should().Be(10);
+            ((ReadOnlySpan<int>)arr).LowerBound(new ArrayLengthComparable(10)).Should().Be(10);
+
+            arr.UpperBound(new ArrayLengthComparable(10)).Should().Be(10);
+            ((IList<int>)arr).UpperBound(new ArrayLengthComparable(10)).Should().Be(10);
+            ((Span<int>)arr).UpperBound(new ArrayLengthComparable(10)).Should().Be(10);
+            ((ReadOnlySpan<int>)arr).UpperBound(new ArrayLengthComparable(10)).Should().Be(10);
+
+            arr.LowerBound(new ArrayLengthComparable(100)).Should().Be(10);
+            ((IList<int>)arr).LowerBound(new ArrayLengthComparable(100)).Should().Be(10);
+            ((Span<int>)arr).LowerBound(new ArrayLengthComparable(100)).Should().Be(10);
+            ((ReadOnlySpan<int>)arr).LowerBound(new ArrayLengthComparable(100)).Should().Be(10);
+
+            arr.UpperBound(new ArrayLengthComparable(100)).Should().Be(11);
+            ((IList<int>)arr).UpperBound(new ArrayLengthComparable(100)).Should().Be(11);
+            ((Span<int>)arr).UpperBound(new ArrayLengthComparable(100)).Should().Be(11);
+            ((ReadOnlySpan<int>)arr).UpperBound(new ArrayLengthComparable(100)).Should().Be(11);
+
+            arr.LowerBound(new ArrayLengthComparable(101)).Should().Be(11);
+            ((IList<int>)arr).LowerBound(new ArrayLengthComparable(101)).Should().Be(11);
+            ((Span<int>)arr).LowerBound(new ArrayLengthComparable(101)).Should().Be(11);
+            ((ReadOnlySpan<int>)arr).LowerBound(new ArrayLengthComparable(101)).Should().Be(11);
+
+            arr.UpperBound(new ArrayLengthComparable(101)).Should().Be(11);
+            ((IList<int>)arr).UpperBound(new ArrayLengthComparable(101)).Should().Be(11);
+            ((Span<int>)arr).UpperBound(new ArrayLengthComparable(101)).Should().Be(11);
+            ((ReadOnlySpan<int>)arr).UpperBound(new ArrayLengthComparable(101)).Should().Be(11);
+        }
+
+        struct ArrayLengthComparable : IComparable<int>
+        {
+            Array s;
+            public ArrayLengthComparable(int length) { s = new byte[length]; }
+            public ArrayLengthComparable(Array s) { this.s = s; }
+            public int CompareTo(int other) => s.Length.CompareTo(other);
         }
 
         [Fact]


### PR DESCRIPTION
Fix #77 