### PR TITLE
重い Contract.Assert をコメントアウト

### DIFF
--- a/Source/ac-library-csharp/DataStructure/FenwickTree.GenericMath.cs
+++ b/Source/ac-library-csharp/DataStructure/FenwickTree.GenericMath.cs
@@ -29,7 +29,7 @@ namespace AtCoder
         public int Length { get; }
 
         /// <summary>
-        /// 長さ <paramref name="n"/> の配列aを持つ <see cref="FenwickTree{TValue, TOp}"/> クラスの新しいインスタンスを作ります。
+        /// 長さ <paramref name="n"/> の配列aを持つ <see cref="FenwickTree{TValue}"/> クラスの新しいインスタンスを作ります。
         /// </summary>
         /// <remarks>
         /// <para>制約: 0≤<paramref name="n"/>≤10^8</para>
@@ -70,7 +70,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public TValue Sum(int l, int r)
         {
-            Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
+            Contract.Assert((uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             return Sum(r) - Sum(l);
         }
 

--- a/Source/ac-library-csharp/DataStructure/FenwickTree.cs
+++ b/Source/ac-library-csharp/DataStructure/FenwickTree.cs
@@ -76,7 +76,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public TValue Sum(int l, int r)
         {
-            Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
+            Contract.Assert((uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             return op.Subtract(Sum(r), Sum(l));
         }
 

--- a/Source/ac-library-csharp/DataStructure/LazySegtree.cs
+++ b/Source/ac-library-csharp/DataStructure/LazySegtree.cs
@@ -136,7 +136,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public TValue Prod(int l, int r)
         {
-            Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
+            Contract.Assert((uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             if (l == r) return op.Identity;
 
             l += size;
@@ -196,7 +196,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public void Apply(int l, int r, F f)
         {
-            Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
+            Contract.Assert((uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             if (l == r) return;
 
             l += size;

--- a/Source/ac-library-csharp/DataStructure/Segtree.cs
+++ b/Source/ac-library-csharp/DataStructure/Segtree.cs
@@ -114,7 +114,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public TValue Prod(int l, int r)
         {
-            Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
+            Contract.Assert((uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             TValue sml = op.Identity, smr = op.Identity;
             l += size;
             r += size;

--- a/Source/ac-library-csharp/Graph/DSU.cs
+++ b/Source/ac-library-csharp/Graph/DSU.cs
@@ -36,8 +36,8 @@ namespace AtCoder
         [MethodImpl(256)]
         public int Merge(int a, int b)
         {
-            Contract.Assert(0 <= a && a < _n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
-            Contract.Assert(0 <= b && b < _n, reason: $"IndexOutOfRange: 0 <= {nameof(b)} && {nameof(b)} < _n");
+            Contract.Assert((uint)a < (uint)_n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
+            Contract.Assert((uint)b < (uint)_n, reason: $"IndexOutOfRange: 0 <= {nameof(b)} && {nameof(b)} < _n");
             int x = Leader(a), y = Leader(b);
             if (x == y) return x;
             if (-_parentOrSize[x] < -_parentOrSize[y]) (x, y) = (y, x);
@@ -56,8 +56,8 @@ namespace AtCoder
         [MethodImpl(256)]
         public bool Same(int a, int b)
         {
-            Contract.Assert(0 <= a && a < _n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
-            Contract.Assert(0 <= b && b < _n, reason: $"IndexOutOfRange: 0 <= {nameof(b)} && {nameof(b)} < _n");
+            Contract.Assert((uint)a < (uint)_n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
+            Contract.Assert((uint)b < (uint)_n, reason: $"IndexOutOfRange: 0 <= {nameof(b)} && {nameof(b)} < _n");
             return Leader(a) == Leader(b);
         }
 
@@ -71,7 +71,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public int Leader(int a)
         {
-            Contract.Assert(0 <= a && a < _n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
+            Contract.Assert((uint)a < (uint)_n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
             if (_parentOrSize[a] < 0) return a;
             while (0 <= _parentOrSize[_parentOrSize[a]])
             {
@@ -91,7 +91,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public int Size(int a)
         {
-            Contract.Assert(0 <= a && a < _n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
+            Contract.Assert((uint)a < (uint)_n, reason: $"IndexOutOfRange: 0 <= {nameof(a)} && {nameof(a)} < _n");
             return -_parentOrSize[Leader(a)];
         }
 

--- a/Source/ac-library-csharp/Internal/Contract.cs
+++ b/Source/ac-library-csharp/Internal/Contract.cs
@@ -1,29 +1,45 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace AtCoder.Internal
 {
 
     public static class Contract
     {
+#if NET6_0_OR_GREATER
         /// <summary>
         /// if <paramref name="condition"/> is false, throw exception.
         /// </summary>
         [Conditional("ATCODER_CONTRACT")]
+        [MethodImpl(256)]
+        public static void Assert(bool condition, DefaultInterpolatedStringHandler reason)
+        {
+            if (!condition)
+                Throw(reason.ToStringAndClear());
+        }
+#endif
+        /// <summary>
+        /// if <paramref name="condition"/> is false, throw exception.
+        /// </summary>
+        [Conditional("ATCODER_CONTRACT")]
+        [MethodImpl(256)]
         public static void Assert(bool condition, string reason = null)
         {
             if (!condition)
-                throw new ContractAssertException(reason);
+                Throw(reason);
         }
 
         /// <summary>
         /// if <paramref name="conditionFunc"/>() is false, throw exception.
         /// </summary>
         [Conditional("ATCODER_CONTRACT")]
+        [MethodImpl(256)]
         public static void Assert(Func<bool> conditionFunc, string reason = null)
         {
             if (!conditionFunc())
-                throw new ContractAssertException(reason);
+                Throw(reason);
         }
+        static void Throw(string reason) => throw new ContractAssertException(reason);
     }
 }

--- a/Source/ac-library-csharp/Math/DynamicModInt.cs
+++ b/Source/ac-library-csharp/Math/DynamicModInt.cs
@@ -33,7 +33,7 @@ namespace AtCoder
     /// <typeparam name="T">mod の ID を表す構造体</typeparam>
     /// <example>
     /// <code>
-    /// using AtCoder.ModInt = AtCoder.DynamicModInt&lt;AtCoder.ModID0&gt;;
+    /// using AtCoder.ModInt = AtCoder.DynamicModInt&lt;AtCoder.DynamicModID0&gt;;
     ///
     /// void SomeMethod()
     /// {
@@ -88,8 +88,8 @@ namespace AtCoder
         public static DynamicModInt<T> Raw(int v)
         {
             var u = unchecked((uint)v);
-            Contract.Assert(bt != null, $"{nameof(DynamicModInt<T>)}<{nameof(T)}>.{nameof(Mod)} is undefined.");
-            Contract.Assert(u < Mod, $"{nameof(u)} must be less than {nameof(Mod)}.");
+            //Contract.Assert(bt != null, $"{nameof(DynamicModInt<T>)}<{nameof(T)}>.{nameof(Mod)} is undefined.");
+            //Contract.Assert(u < Mod, $"{nameof(u)} must be less than {nameof(Mod)}.");
             return new DynamicModInt<T>(u);
         }
 

--- a/Source/ac-library-csharp/Math/Internal/InternalMath.cs
+++ b/Source/ac-library-csharp/Math/Internal/InternalMath.cs
@@ -136,8 +136,6 @@ namespace AtCoder.Internal
         [MethodImpl(256)]
         public static bool IsPrime(int n)
         {
-            Contract.Assert(0 <= n);
-            Contract.Assert(0 <= n, reason: $"{nameof(n)} must not be negative.");
             if (n <= 1) return false;
             if (n == 2 || n == 7 || n == 61) return true;
             if (n % 2 == 0) return false;

--- a/Source/ac-library-csharp/Math/StaticModInt.cs
+++ b/Source/ac-library-csharp/Math/StaticModInt.cs
@@ -92,7 +92,7 @@ namespace AtCoder
         public static StaticModInt<T> Raw(int v)
         {
             var u = unchecked((uint)v);
-            Contract.Assert(u < Mod, $"{nameof(u)} must be less than {nameof(Mod)}.");
+            //Contract.Assert(u < Mod, $"{nameof(u)} must be less than {nameof(Mod)}.");
             return new StaticModInt<T>(u);
         }
 

--- a/Source/ac-library-csharp/String/StringLib.cs
+++ b/Source/ac-library-csharp/String/StringLib.cs
@@ -150,8 +150,8 @@ namespace AtCoder
         [MethodImpl(256)]
         public static int[] SuffixArray(int[] s, int upper)
         {
-            Contract.Assert(0U <= (uint)upper, reason: $"{nameof(upper)} must be positive.");
-            Contract.Assert(s.All(si => (uint)si <= (uint)upper), reason: $"si ∈ {nameof(s)} must be 0 <= si && si <= {nameof(upper)}");
+            Contract.Assert(0 <= upper, reason: $"{nameof(upper)} must be positive.");
+            //Contract.Assert(s.All(si => (uint)si <= (uint)upper), reason: $"si ∈ {nameof(s)} must be 0 <= si && si <= {nameof(upper)}");
             return InternalString.SAIS(s, upper);
         }
         #endregion SuffixArray


### PR DESCRIPTION
Fix #89

動作に影響が大きい箇所の `Contract.Assert` をコメントアウトした