### PR TITLE
Multiply 128Bit in barrett reduction

### DIFF
--- a/Source/ac-library-csharp/Math/Internal/Barrett.cs
+++ b/Source/ac-library-csharp/Math/Internal/Barrett.cs
@@ -1,8 +1,4 @@
-﻿#if NETCOREAPP3_0_OR_GREATER
-using System.Runtime.Intrinsics.X86;
-#endif
-using System.Runtime.CompilerServices;
-
+﻿using System.Runtime.CompilerServices;
 
 namespace AtCoder.Internal
 {
@@ -24,19 +20,15 @@ namespace AtCoder.Internal
         /// <paramref name="a"/> * <paramref name="b"/> mod m
         /// </summary>
         [MethodImpl(256)]
-        public uint Mul(uint a, uint b)
+        public uint Mul(uint a, uint b) => Reduce((ulong)a * b);
+
+        [MethodImpl(256)]
+        public uint Reduce(ulong z)
         {
-            var z = (ulong)a * b;
-#if NETCOREAPP3_0_OR_GREATER
-            if (Bmi2.X64.IsSupported)
-            {
-                var x = Bmi2.X64.MultiplyNoFlags(z, IM);
-                var v = unchecked((uint)(z - x * Mod));
-                if (Mod <= v) v += Mod;
-                return v;
-            }
-#endif
-            return (uint)(z % Mod);
+            var x = InternalMath.Mul128Bit(z, IM);
+            var v = unchecked((uint)(z - x * Mod));
+            if (Mod <= v) v += Mod;
+            return v;
         }
     }
 }

--- a/Source/ac-library-csharp/Math/Internal/InternalMath.cs
+++ b/Source/ac-library-csharp/Math/Internal/InternalMath.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 #if NETCOREAPP3_1_OR_GREATER
+using System.Runtime.Intrinsics.X86;
 using System.Numerics;
 #endif
 
@@ -159,14 +160,14 @@ namespace AtCoder.Internal
             return true;
         }
         /// <summary>
-        /// Same as <see cref="MathLib.PowMod(long, long, int)"/>
+        /// <inheritdoc cref="MathLib.PowMod(long, long, int)" />
         /// </summary>
         [MethodImpl(256)]
-        private static long PowMod(long x, long n, int m)
+        internal static long PowMod(long x, long n, int m)
         {
             Contract.Assert(0 <= n && 1 <= m, reason: $"0 <= {nameof(n)} && 1 <= {nameof(m)}");
             if (m == 1) return 0;
-            Barrett barrett = new Barrett((uint)m);
+            var barrett = new Barrett((uint)m);
             uint r = 1, y = (uint)SafeMod(x, m);
             while (0 < n)
             {
@@ -198,6 +199,84 @@ namespace AtCoder.Internal
                 if (yMax < m) return ans;
                 (n, m, a, b) = (yMax / m, a, m, yMax % m);
             }
+        }
+
+        /// <summary>
+        /// <paramref name="a"/> * <paramref name="b"/> の上位 64 ビットを返します。
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        [MethodImpl(256)]
+        internal static ulong Mul128Bit(ulong a, ulong b)
+        {
+#if NETCOREAPP3_1_OR_GREATER
+            if (Bmi2.X64.IsSupported)
+                return Bmi2.X64.MultiplyNoFlags(a, b);
+#endif
+            return Mul128BitLogic(a, b);
+        }
+
+        /// <summary>
+        /// <paramref name="a"/> * <paramref name="b"/> の上位 64 ビットを返します。
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        [MethodImpl(256)]
+        internal static ulong Mul128BitLogic(ulong a, ulong b)
+        {
+            /*
+             * ここでは 64 bit 整数 X の上位, 下位 32 bit をそれぞれ Xu ,Xd と表す
+             * A * B を計算する。
+             * 
+             * 変数を下記のように定義する。
+             * s := 1ul << 32
+             * R := A * B
+             * L  := Ad * Bd
+             * M1 := Ad * Bu
+             * M2 := Au * Bd
+             * H  := Au * Bu
+             * 
+             * A * B = s * s * H + s * (M1 + M2) + L
+             * であることを使って
+             * R = s * s * x + y
+             * と表せる x, y を求めたい (x, y < s * s)
+             * 
+             * A * B
+             * = s * s * H + s * (s * M1u + M1d + s * M2u + M2d) + L
+             * = s * s * H + s * (s * (M1u + M2u) + M1d + M2d) + L
+             * = s * s * (H + M1u + M2u) + s * (M1d + M2d) + L
+             * 
+             * と表せるので、繰り上がりを考慮しなければ
+             * x = H + M1u + M2u
+             * y = s * (M1d + M2d) + L = s * (M1d + M2d + Lu) + Ld
+             * となる
+             * 
+             * 繰り上がるのは
+             * M1d + M2d + Lu の上位 32 bit なので
+             * C := M1d + M2d + Lu
+             * とすると
+             * 
+             * x = H + M1u + M2u + Cu
+             * となる
+             */
+            var au = a >> 32;
+            var ad = a & 0xFFFFFFFF;
+            var bu = b >> 32;
+            var bd = b & 0xFFFFFFFF;
+
+            var l = ad * bd;
+            var m1 = au * bd;
+            var m2 = ad * bu;
+            var h = au * bu;
+
+            var lu = l >> 32;
+            var m1d = m1 & 0xFFFFFFFF;
+            var m2d = m2 & 0xFFFFFFFF;
+            var c = m1d + m2d + lu;
+
+            return h + (m1 >> 32) + (m2 >> 32) + (c >> 32);
         }
     }
 }

--- a/Test/ac-library-csharp.Test/Internal/BarrettTest.cs
+++ b/Test/ac-library-csharp.Test/Internal/BarrettTest.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace AtCoder.Internal
+{
+    public class BarrettTest
+    {
+        [Fact]
+        public void Barrett()
+        {
+            for (uint m = 1; m <= 100; m++)
+            {
+                var bt = new Barrett(m);
+                for (uint a = 0; a < m; a++)
+                {
+                    for (uint b = 0; b < m; b++)
+                    {
+                        bt.Mul(a, b).Should().Be((a * b) % m);
+                    }
+                }
+            }
+
+            new Barrett(1).Mul(0, 0).Should().Be(0);
+        }
+
+        [Fact]
+        public void BarrettBorder()
+        {
+            for (uint mod = int.MaxValue; mod >= int.MaxValue - 20; mod--)
+            {
+                var bt = new Barrett(mod);
+                var v = new List<uint>();
+                for (uint i = 0; i < 10; i++)
+                {
+                    v.Add(i);
+                    v.Add(mod - i);
+                    v.Add(mod / 2 + i);
+                    v.Add(mod / 2 - i);
+                }
+                foreach (var a in v)
+                {
+                    long a2 = a;
+                    bt.Mul(a, bt.Mul(a, a)).Should().Be((uint)(a2 * a2 % mod * a2 % mod));
+                    foreach (var b in v)
+                    {
+                        long b2 = b;
+                        bt.Mul(a, b).Should().Be((uint)(a2 * b2 % mod));
+                    }
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.13.4, OS=Windows 10 (10.0.19045.2486)
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.101
  [Host]   : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
  ShortRun : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
|          Method |     Toolchain |     Mean |     Error |    StdDev |
|---------------- |-------------- |---------:|----------:|----------:|
| MultiplyNoFlags |      .NET 7.0 | 1.137 ms | 0.1722 ms | 0.0094 ms |
| MultiplyNoFlags | .NET Core 3.1 | 1.159 ms | 0.6725 ms | 0.0369 ms |
|                 |               |          |           |           |
|       Mul128Bit |      .NET 7.0 | 2.208 ms | 1.9935 ms | 0.1093 ms |
|       Mul128Bit | .NET Core 3.1 | 2.175 ms | 0.1901 ms | 0.0104 ms |
|                 |               |          |           |           |
|         Modulus |      .NET 7.0 | 4.647 ms | 0.4117 ms | 0.0226 ms |
|         Modulus | .NET Core 3.1 | 4.696 ms | 0.6656 ms | 0.0365 ms |
