### PR TITLE
Separate `MathLib` and `InternalMath` implementations in separate classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2023-10-26
+### Changed
+- Separate `MathLib` and `InternalMath` implementations in separate classes
+
 ## [3.3.0] - 2023-10-25
 ### Added
 - Add `IModInt<T>.Value` and `IModInt<T>.Mod`

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <RepositoryUrl>https://github.com/kzrnm/ac-library-csharp</RepositoryUrl>
     <PackageReleaseNotes>https://github.com/kzrnm/ac-library-csharp/blob/main/CHANGELOG.md</PackageReleaseNotes>
 
-    <Version>3.3.0</Version>
-    <AssemblyVersion>3.3.0.101</AssemblyVersion>
+    <Version>3.4.0</Version>
+    <AssemblyVersion>3.4.0.101</AssemblyVersion>
     <RepositoryCommit Condition="'$(GIT_COMMIT)' != ''">$(GIT_COMMIT)</RepositoryCommit>
 
     <SignAssembly>True</SignAssembly>

--- a/Source/ac-library-csharp/Math/Internal/Barrett.cs
+++ b/Source/ac-library-csharp/Math/Internal/Barrett.cs
@@ -25,7 +25,7 @@ namespace AtCoder.Internal
         [MethodImpl(256)]
         public uint Reduce(ulong z)
         {
-            var x = InternalMath.Mul128Bit(z, IM);
+            var x = BigMul.Mul128Bit(z, IM);
             var y = x * Mod;
             if (z < y) return (uint)(z - y + Mod);
             return (uint)(z - y);
@@ -56,7 +56,7 @@ namespace AtCoder.Internal
         public uint Pow(long x, ulong n)
         {
             if (Mod == 1) return 0;
-            uint r = 1, y = (uint)InternalMath.SafeMod(x, Mod);
+            uint r = 1, y = (uint)ModCalc.SafeMod(x, Mod);
             while (n > 0)
             {
                 if ((n & 1) != 0) r = Mul(r, y);

--- a/Source/ac-library-csharp/Math/Internal/BigMul.cs
+++ b/Source/ac-library-csharp/Math/Internal/BigMul.cs
@@ -1,0 +1,88 @@
+﻿using System.Runtime.CompilerServices;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace AtCoder.Internal
+{
+    public static class BigMul
+    {
+        /// <summary>
+        /// <paramref name="a"/> * <paramref name="b"/> の上位 64 ビットを返します。
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        [MethodImpl(256)]
+        public static ulong Mul128Bit(ulong a, ulong b)
+        {
+#if NETCOREAPP3_1_OR_GREATER
+            if (Bmi2.X64.IsSupported)
+                return Bmi2.X64.MultiplyNoFlags(a, b);
+#endif
+            return Mul128BitLogic(a, b);
+        }
+
+        /// <summary>
+        /// <paramref name="a"/> * <paramref name="b"/> の上位 64 ビットを返します。
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        [MethodImpl(256)]
+        internal static ulong Mul128BitLogic(ulong a, ulong b)
+        {
+            /*
+             * ここでは 64 bit 整数 X の上位, 下位 32 bit をそれぞれ Xu ,Xd と表す
+             * A * B を計算する。
+             * 
+             * 変数を下記のように定義する。
+             * s := 1ul << 32
+             * R := A * B
+             * L  := Ad * Bd
+             * M1 := Ad * Bu
+             * M2 := Au * Bd
+             * H  := Au * Bu
+             * 
+             * A * B = s * s * H + s * (M1 + M2) + L
+             * であることを使って
+             * R = s * s * x + y
+             * と表せる x, y を求めたい (x, y < s * s)
+             * 
+             * A * B
+             * = s * s * H + s * (s * M1u + M1d + s * M2u + M2d) + L
+             * = s * s * H + s * (s * (M1u + M2u) + M1d + M2d) + L
+             * = s * s * (H + M1u + M2u) + s * (M1d + M2d) + L
+             * 
+             * と表せるので、繰り上がりを考慮しなければ
+             * x = H + M1u + M2u
+             * y = s * (M1d + M2d) + L = s * (M1d + M2d + Lu) + Ld
+             * となる
+             * 
+             * 繰り上がるのは
+             * M1d + M2d + Lu の上位 32 bit なので
+             * C := M1d + M2d + Lu
+             * とすると
+             * 
+             * x = H + M1u + M2u + Cu
+             * となる
+             */
+            var au = a >> 32;
+            var ad = a & 0xFFFFFFFF;
+            var bu = b >> 32;
+            var bd = b & 0xFFFFFFFF;
+
+            var l = ad * bd;
+            var m1 = au * bd;
+            var m2 = ad * bu;
+            var h = au * bu;
+
+            var lu = l >> 32;
+            var m1d = m1 & 0xFFFFFFFF;
+            var m2d = m2 & 0xFFFFFFFF;
+            var c = m1d + m2d + lu;
+
+            return h + (m1 >> 32) + (m2 >> 32) + (c >> 32);
+        }
+    }
+}

--- a/Source/ac-library-csharp/Math/Internal/Butterfly.cs
+++ b/Source/ac-library-csharp/Math/Internal/Butterfly.cs
@@ -193,7 +193,7 @@ namespace AtCoder.Internal
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static StaticModInt<T>[] CalcurateSumE()
         {
-            int g = InternalMath.PrimitiveRoot<T>();
+            int g = ModPrimitiveRoot.PrimitiveRoot<T>();
             int cnt2 = InternalBit.Bsf(default(T).Mod - 1);
             var e = new StaticModInt<T>(g).Pow((default(T).Mod - 1) >> cnt2);
             var ie = e.Inv();
@@ -238,7 +238,7 @@ namespace AtCoder.Internal
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static StaticModInt<T>[] CalcurateSumIE()
         {
-            int g = InternalMath.PrimitiveRoot<T>();
+            int g = ModPrimitiveRoot.PrimitiveRoot<T>();
             int cnt2 = InternalBit.Bsf(default(T).Mod - 1);
             var e = new StaticModInt<T>(g).Pow((default(T).Mod - 1) >> cnt2);
             var ie = e.Inv();

--- a/Source/ac-library-csharp/Math/Internal/Convolution.cs
+++ b/Source/ac-library-csharp/Math/Internal/Convolution.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
+
+namespace AtCoder.Internal
+{
+    public static class ConvolutionImpl
+    {
+        /// <summary>
+        /// 畳み込みを mod <typeparamref name="TMod"/> で計算します。
+        /// </summary>
+        /// <remarks>
+        /// <para><paramref name="a"/>, <paramref name="b"/> の少なくとも一方が空の場合は空配列を返します。</para>
+        /// <para>制約:</para>
+        /// <para>- 2≤<typeparamref name="TMod"/>≤2×10^9</para>
+        /// <para>- <typeparamref name="TMod"/> は素数</para>
+        /// <para>- 2^c | (<typeparamref name="TMod"/> - 1) かつ |<paramref name="a"/>| + |<paramref name="b"/>| - 1 ≤ 2^c なる c が存在する</para>
+        /// <para>計算量: O((|<paramref name="a"/>|+|<paramref name="b"/>|)log(|<paramref name="a"/>|+|<paramref name="b"/>|) + log<typeparamref name="TMod"/>)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static StaticModInt<TMod>[] Convolution<TMod>(ReadOnlySpan<StaticModInt<TMod>> a, ReadOnlySpan<StaticModInt<TMod>> b)
+            where TMod : struct, IStaticMod
+        {
+            var n = a.Length;
+            var m = b.Length;
+            if (n == 0 || m == 0)
+                return Array.Empty<StaticModInt<TMod>>();
+            if (Math.Min(n, m) <= 60)
+                return ConvolutionNaive(a, b);
+            return ConvolutionFFT(a, b);
+        }
+
+        [MethodImpl(256)]
+        private static StaticModInt<TMod>[] ConvolutionFFT<TMod>(ReadOnlySpan<StaticModInt<TMod>> a, ReadOnlySpan<StaticModInt<TMod>> b)
+            where TMod : struct, IStaticMod
+        {
+            int n = a.Length, m = b.Length;
+            int z = 1 << InternalBit.CeilPow2(n + m - 1);
+            var a2 = new StaticModInt<TMod>[z];
+            var b2 = new StaticModInt<TMod>[z];
+            a.CopyTo(a2);
+            b.CopyTo(b2);
+
+            var result = ConvolutionFFTInner(a2, b2);
+            Array.Resize(ref result, n + m - 1);
+            var iz = new StaticModInt<TMod>(z).Inv();
+            for (int i = 0; i < result.Length; i++)
+                result[i] *= iz;
+
+            return result;
+        }
+
+        [MethodImpl(256)]
+        private static StaticModInt<TMod>[] ConvolutionFFTInner<TMod>(StaticModInt<TMod>[] a, StaticModInt<TMod>[] b)
+            where TMod : struct, IStaticMod
+        {
+            Butterfly<TMod>.Calculate(a);
+            Butterfly<TMod>.Calculate(b);
+            for (int i = 0; i < a.Length; i++)
+                a[i] *= b[i];
+            Butterfly<TMod>.CalculateInv(a);
+            return a;
+        }
+        [MethodImpl(256)]
+        private static StaticModInt<TMod>[] ConvolutionNaive<TMod>(ReadOnlySpan<StaticModInt<TMod>> a, ReadOnlySpan<StaticModInt<TMod>> b)
+            where TMod : struct, IStaticMod
+        {
+            if (a.Length < b.Length)
+            {
+                var temp = a;
+                a = b;
+                b = temp;
+            }
+
+            var ans = new StaticModInt<TMod>[a.Length + b.Length - 1];
+            for (int i = 0; i < a.Length; i++)
+            {
+                for (int j = 0; j < b.Length; j++)
+                {
+                    ans[i + j] += a[i] * b[j];
+                }
+            }
+
+            return ans;
+        }
+
+        /// <summary>
+        /// 畳み込みを計算します。
+        /// </summary>
+        /// <remarks>
+        /// <para><paramref name="a"/>, <paramref name="b"/> の少なくとも一方が空の場合は空配列を返します。</para>
+        /// <para>制約:</para>
+        /// <para>- |<paramref name="a"/>| + |<paramref name="b"/>| - 1 ≤ 2^24 = 16,777,216</para>
+        /// <para>- 畳み込んだ後の配列の要素が全て long に収まる</para>
+        /// <para>計算量: O((|<paramref name="a"/>|+|<paramref name="b"/>|)log(|<paramref name="a"/>|+|<paramref name="b"/>|))</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static long[] ConvolutionLong(ReadOnlySpan<long> a, ReadOnlySpan<long> b)
+        {
+            unchecked
+            {
+                var n = a.Length;
+                var m = b.Length;
+
+                if (n == 0 || m == 0)
+                {
+                    return Array.Empty<long>();
+                }
+
+                const ulong Mod1 = 754974721;  // 2^24
+                const ulong Mod2 = 167772161;  // 2^25
+                const ulong Mod3 = 469762049;  // 2^26
+                const ulong M2M3 = Mod2 * Mod3;
+                const ulong M1M3 = Mod1 * Mod3;
+                const ulong M1M2 = Mod1 * Mod2;
+                // (m1 * m2 * m3) % 2^64
+                const ulong M1M2M3 = Mod1 * Mod2 * Mod3;
+
+                const ulong i1 = 190329765;
+                const ulong i2 = 58587104;
+                const ulong i3 = 187290749;
+
+                Debug.Assert(default(FFTMod1).Mod == Mod1);
+                Debug.Assert(default(FFTMod2).Mod == Mod2);
+                Debug.Assert(default(FFTMod3).Mod == Mod3);
+                Debug.Assert(i1 == (ulong)ModCalc.InvGcd((long)M2M3, (long)Mod1).Item2);
+                Debug.Assert(i2 == (ulong)ModCalc.InvGcd((long)M1M3, (long)Mod2).Item2);
+                Debug.Assert(i3 == (ulong)ModCalc.InvGcd((long)M1M2, (long)Mod3).Item2);
+
+                var c1 = Convolution<FFTMod1>(ToModInt<FFTMod1>(a), ToModInt<FFTMod1>(b));
+                var c2 = Convolution<FFTMod2>(ToModInt<FFTMod2>(a), ToModInt<FFTMod2>(b));
+                var c3 = Convolution<FFTMod3>(ToModInt<FFTMod3>(a), ToModInt<FFTMod3>(b));
+
+                var c = new long[n + m - 1];
+
+                //ReadOnlySpan<ulong> offset = stackalloc ulong[] { 0, 0, M1M2M3, 2 * M1M2M3, 3 * M1M2M3 };
+
+                for (int i = 0; i < c.Length; i++)
+                {
+                    ulong x = 0;
+                    x += ((ulong)c1[i].Value * i1) % Mod1 * M2M3;
+                    x += ((ulong)c2[i].Value * i2) % Mod2 * M1M3;
+                    x += ((ulong)c3[i].Value * i3) % Mod3 * M1M2;
+
+                    long diff = c1[i].Value - ModCalc.SafeMod((long)x, (long)Mod1);
+                    if (diff < 0)
+                    {
+                        diff += (long)Mod1;
+                    }
+
+                    // 真値を r, 得られた値を x, M1M2M3 % 2^64 = M', B = 2^63 として、
+                    // r = x,
+                    //     x -  M' + (0 or 2B),
+                    //     x - 2M' + (0 or 2B or 4B),
+                    //     x - 3M' + (0 or 2B or 4B or 6B)
+                    // のいずれかが成り立つ、らしい
+                    // -> see atcoder/convolution.hpp
+                    switch (diff % 5)
+                    {
+                        case 2:
+                            x -= M1M2M3;
+                            break;
+                        case 3:
+                            x -= 2 * M1M2M3;
+                            break;
+                        case 4:
+                            x -= 3 * M1M2M3;
+                            break;
+                    }
+                    c[i] = (long)x;
+                }
+
+                return c;
+            }
+        }
+        static StaticModInt<T>[] ToModInt<T>(ReadOnlySpan<long> a) where T : struct, IStaticMod
+        {
+            if (a.IsEmpty) return Array.Empty<StaticModInt<T>>();
+
+            var c = new StaticModInt<T>[a.Length];
+#if NETCOREAPP3_1_OR_GREATER
+            ref var ap = ref MemoryMarshal.GetReference(a);
+            for (int i = 0; i < c.Length; i++)
+                c[i] = Unsafe.Add(ref ap, i);
+#else
+            for (int i = 0; i < c.Length; i++)
+                c[i] = a[i];
+#endif
+            return c;
+        }
+
+        private readonly struct FFTMod1 : IStaticMod
+        {
+            public uint Mod => 754974721;
+            public bool IsPrime => true;
+        }
+
+        private readonly struct FFTMod2 : IStaticMod
+        {
+            public uint Mod => 167772161;
+            public bool IsPrime => true;
+        }
+
+        private readonly struct FFTMod3 : IStaticMod
+        {
+            public uint Mod => 469762049;
+            public bool IsPrime => true;
+        }
+    }
+}

--- a/Source/ac-library-csharp/Math/Internal/FloorSum.cs
+++ b/Source/ac-library-csharp/Math/Internal/FloorSum.cs
@@ -1,0 +1,67 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace AtCoder.Internal
+{
+    public static class FloorSum
+    {
+        /// <summary>
+        /// sum_{i=0}^{<paramref name="n"/>-1} floor(<paramref name="a"/>*i+<paramref name="b"/>/<paramref name="m"/>) を返します。答えがオーバーフローしたならば  mod2^64 で等しい値を返します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約:</para>
+        /// <para> 0≤<paramref name="n"/>&lt;2^32</para>
+        /// <para> 1≤<paramref name="m"/>&lt;2^32</para>
+        /// <para>計算量: O(log(m))</para>
+        /// </remarks>
+        /// <returns></returns>
+        [MethodImpl(256)]
+        public static long FloorSumSigned(long n, long m, long a, long b)
+        {
+            Contract.Assert(0 <= n && n < (1L << 32));
+            Contract.Assert(1 <= m && m < (1L << 32));
+            var nn = (ulong)n;
+            var mm = (ulong)m;
+            ulong aa, bb;
+            ulong ans = 0;
+            if (a < 0)
+            {
+                var a2 = (ulong)ModCalc.SafeMod(a, m);
+                ans -= nn * (nn - 1) / 2 * ((a2 - (ulong)a) / mm);
+                aa = a2;
+            }
+            else aa = (ulong)a;
+            if (b < 0)
+            {
+                var b2 = (ulong)ModCalc.SafeMod(b, m);
+                ans -= nn * ((b2 - (ulong)b) / mm);
+                bb = b2;
+            }
+            else bb = (ulong)b;
+
+            return (long)(ans + FloorSumUnsigned(nn, mm, aa, bb));
+        }
+
+        [MethodImpl(256)]
+        public static ulong FloorSumUnsigned(ulong n, ulong m, ulong a, ulong b)
+        {
+            ulong ans = 0;
+            while (true)
+            {
+                if (a >= m)
+                {
+                    ans += (n - 1) * n / 2 * (a / m);
+                    a %= m;
+                }
+                if (b >= m)
+                {
+                    ans += n * (b / m);
+                    b %= m;
+                }
+
+                ulong yMax = a * n + b;
+                if (yMax < m) return ans;
+                (n, m, a, b) = (yMax / m, a, m, yMax % m);
+            }
+        }
+    }
+}

--- a/Source/ac-library-csharp/Math/Internal/InternalMath.cs
+++ b/Source/ac-library-csharp/Math/Internal/InternalMath.cs
@@ -1,135 +1,33 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1_OR_GREATER
-using System.Runtime.Intrinsics.X86;
-using System.Numerics;
-#endif
+
 
 namespace AtCoder.Internal
 {
     public static class InternalMath
     {
-        private static readonly Dictionary<uint, int> primitiveRootsCache = new Dictionary<uint, int>()
-        {
-            { 2, 1 },
-            { 167772161, 3 },
-            { 469762049, 3 },
-            { 754974721, 11 },
-            { 998244353, 3 }
-        };
-
-        /// <summary>
-        /// <typeparamref name="TMod"/> の最小の原始根を求めます。
-        /// </summary>
-        /// <remarks>
-        /// 制約: <typeparamref name="TMod"/> は素数
-        /// </remarks>
+        /// <inheritdoc cref="ModPrimitiveRoot.PrimitiveRoot{TMod}" />
         [MethodImpl(256)]
-        public static int PrimitiveRoot<TMod>() where TMod : struct, IStaticMod
-        {
-            uint m = default(TMod).Mod;
-            Contract.Assert(m >= 2, reason: $"{nameof(m)} must be greater or equal 2");
-            Contract.Assert(default(TMod).IsPrime, reason: $"{nameof(m)} must be prime number");
+        public static int PrimitiveRoot<TMod>() where TMod : struct, IStaticMod => ModPrimitiveRoot.PrimitiveRoot<TMod>();
 
-#if NET7_0_OR_GREATER
-            ref var result = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(primitiveRootsCache, m, out var exists);
-            if (!exists)
-            {
-                result = PrimitiveRootCalculate<TMod>();
-            }
-            return result;
-#else
-            if (primitiveRootsCache.TryGetValue(m, out var p))
-            {
-                return p;
-            }
-
-            return primitiveRootsCache[m] = PrimitiveRootCalculate<TMod>();
-#endif
-        }
-        static int PrimitiveRootCalculate<TMod>() where TMod : struct, IStaticMod
-        {
-            var m = default(TMod).Mod;
-            Span<uint> divs = stackalloc uint[20];
-            divs[0] = 2;
-            int cnt = 1;
-            var x = m - 1;
-            x >>= BitOperations.TrailingZeroCount(x);
-
-            for (uint i = 3; (long)i * i <= x; i += 2)
-            {
-                if (x % i == 0)
-                {
-                    divs[cnt++] = i;
-                    do
-                    {
-                        x /= i;
-                    } while (x % i == 0);
-                }
-            }
-
-            if (x > 1)
-            {
-                divs[cnt++] = x;
-            }
-            divs = divs.Slice(0, cnt);
-
-            for (int g = 2; ; g++)
-            {
-                foreach (var d in divs)
-                    if (new StaticModInt<TMod>(g).Pow((m - 1) / d).Value == 1)
-                        goto NEXT;
-                return g;
-            NEXT:;
-            }
-        }
-
-        /// <summary>
-        /// g=gcd(a,b),xa=g(mod b) となるような 0≤x&lt;b/g の(g, x)
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: 1≤<paramref name="b"/></para>
-        /// </remarks>
+        /// <inheritdoc cref="ModCalc.InvGcd(long, long)" />
         [MethodImpl(256)]
         public static (long, long) InvGcd(long a, long b)
-        {
-            a = SafeMod(a, b);
-            if (a == 0) return (b, 0);
+            => ModCalc.InvGcd(a, b);
 
-            long s = b, t = a;
-            long m0 = 0, m1 = 1;
-
-            long u;
-            while (true)
-            {
-                if (t == 0)
-                {
-                    if (m0 < 0) m0 += b / s;
-                    return (s, m0);
-                }
-                u = s / t;
-                s -= t * u;
-                m0 -= m1 * u;
-
-                if (s == 0)
-                {
-                    if (m1 < 0) m1 += b / t;
-                    return (t, m1);
-                }
-                u = t / s;
-                t -= s * u;
-                m1 -= m0 * u;
-            }
-        }
-
+        /// <inheritdoc cref="ModCalc.SafeMod(long, long)" />
         [MethodImpl(256)]
         public static long SafeMod(long x, long m)
-        {
-            x %= m;
-            if (x < 0) x += m;
-            return x;
-        }
+            => ModCalc.SafeMod(x, m);
+
+        /// <inheritdoc cref="ModCalc.PowMod(long, long, int)" />
+        [MethodImpl(256)]
+        public static uint PowMod(long x, long n, int m)
+            => ModCalc.PowMod(x, n, m);
+
+        /// <inheritdoc cref="BigMul.Mul128Bit(ulong, ulong)" />
+        [MethodImpl(256)]
+        public static ulong Mul128Bit(ulong a, ulong b) => BigMul.Mul128Bit(a, b);
 
         /// <summary>
         /// <paramref name="n"/> が素数かを返します。
@@ -159,116 +57,10 @@ namespace AtCoder.Internal
             }
             return true;
         }
-        /// <summary>
-        /// <inheritdoc cref="MathLib.PowMod(long, long, int)" />
-        /// </summary>
-        [MethodImpl(256)]
-        public static uint PowMod(long x, long n, int m)
-        {
-            Contract.Assert(0 <= n && 1 <= m, reason: $"0 <= {nameof(n)} && 1 <= {nameof(m)}");
-            if (m == 1) return 0;
-            return new Barrett((uint)m).Pow(x, n);
-        }
 
+        /// <inheritdoc cref="FloorSum.FloorSumUnsigned(ulong, ulong, ulong, ulong)" />
         [MethodImpl(256)]
         public static ulong FloorSumUnsigned(ulong n, ulong m, ulong a, ulong b)
-        {
-            ulong ans = 0;
-            while (true)
-            {
-                if (a >= m)
-                {
-                    ans += (n - 1) * n / 2 * (a / m);
-                    a %= m;
-                }
-                if (b >= m)
-                {
-                    ans += n * (b / m);
-                    b %= m;
-                }
-
-                ulong yMax = a * n + b;
-                if (yMax < m) return ans;
-                (n, m, a, b) = (yMax / m, a, m, yMax % m);
-            }
-        }
-
-        /// <summary>
-        /// <paramref name="a"/> * <paramref name="b"/> の上位 64 ビットを返します。
-        /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
-        /// <returns></returns>
-        [MethodImpl(256)]
-        public static ulong Mul128Bit(ulong a, ulong b)
-        {
-#if NETCOREAPP3_1_OR_GREATER
-            if (Bmi2.X64.IsSupported)
-                return Bmi2.X64.MultiplyNoFlags(a, b);
-#endif
-            return Mul128BitLogic(a, b);
-        }
-
-        /// <summary>
-        /// <paramref name="a"/> * <paramref name="b"/> の上位 64 ビットを返します。
-        /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
-        /// <returns></returns>
-        [MethodImpl(256)]
-        internal static ulong Mul128BitLogic(ulong a, ulong b)
-        {
-            /*
-             * ここでは 64 bit 整数 X の上位, 下位 32 bit をそれぞれ Xu ,Xd と表す
-             * A * B を計算する。
-             * 
-             * 変数を下記のように定義する。
-             * s := 1ul << 32
-             * R := A * B
-             * L  := Ad * Bd
-             * M1 := Ad * Bu
-             * M2 := Au * Bd
-             * H  := Au * Bu
-             * 
-             * A * B = s * s * H + s * (M1 + M2) + L
-             * であることを使って
-             * R = s * s * x + y
-             * と表せる x, y を求めたい (x, y < s * s)
-             * 
-             * A * B
-             * = s * s * H + s * (s * M1u + M1d + s * M2u + M2d) + L
-             * = s * s * H + s * (s * (M1u + M2u) + M1d + M2d) + L
-             * = s * s * (H + M1u + M2u) + s * (M1d + M2d) + L
-             * 
-             * と表せるので、繰り上がりを考慮しなければ
-             * x = H + M1u + M2u
-             * y = s * (M1d + M2d) + L = s * (M1d + M2d + Lu) + Ld
-             * となる
-             * 
-             * 繰り上がるのは
-             * M1d + M2d + Lu の上位 32 bit なので
-             * C := M1d + M2d + Lu
-             * とすると
-             * 
-             * x = H + M1u + M2u + Cu
-             * となる
-             */
-            var au = a >> 32;
-            var ad = a & 0xFFFFFFFF;
-            var bu = b >> 32;
-            var bd = b & 0xFFFFFFFF;
-
-            var l = ad * bd;
-            var m1 = au * bd;
-            var m2 = ad * bu;
-            var h = au * bu;
-
-            var lu = l >> 32;
-            var m1d = m1 & 0xFFFFFFFF;
-            var m2d = m2 & 0xFFFFFFFF;
-            var c = m1d + m2d + lu;
-
-            return h + (m1 >> 32) + (m2 >> 32) + (c >> 32);
-        }
+            => FloorSum.FloorSumUnsigned(n, m, a, b);
     }
 }

--- a/Source/ac-library-csharp/Math/Internal/ModCalc.cs
+++ b/Source/ac-library-csharp/Math/Internal/ModCalc.cs
@@ -1,0 +1,129 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace AtCoder.Internal
+{
+    /// <summary>
+    /// Mod 関連の計算
+    /// </summary>
+    public static class ModCalc
+    {
+        /// <summary>
+        /// <paramref name="x"/>y≡1(mod <paramref name="m"/>) なる y のうち、0≤y&lt;<paramref name="m"/> を満たすものを返します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: gcd(<paramref name="x"/>,<paramref name="m"/>)=1, 1≤<paramref name="m"/></para>
+        /// <para>計算量: O(log<paramref name="m"/>)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static long InvMod(long x, long m)
+        {
+            Contract.Assert(1 <= m, reason: $"1 <= {nameof(m)}");
+            var (g, res) = InvGcd(x, m);
+            Contract.Assert(g == 1, reason: $"gcd({nameof(x)}, {nameof(m)}) must be 1.");
+            return res;
+        }
+
+        /// <summary>
+        /// g=gcd(a,b),xa=g(mod b) となるような 0≤x&lt;b/g の(g, x)
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: 1≤<paramref name="b"/></para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static (long, long) InvGcd(long a, long b)
+        {
+            a = SafeMod(a, b);
+            if (a == 0) return (b, 0);
+
+            long s = b, t = a;
+            long m0 = 0, m1 = 1;
+
+            long u;
+            while (true)
+            {
+                if (t == 0)
+                {
+                    if (m0 < 0) m0 += b / s;
+                    return (s, m0);
+                }
+                u = s / t;
+                s -= t * u;
+                m0 -= m1 * u;
+
+                if (s == 0)
+                {
+                    if (m1 < 0) m1 += b / t;
+                    return (t, m1);
+                }
+                u = t / s;
+                t -= s * u;
+                m1 -= m0 * u;
+            }
+        }
+
+        [MethodImpl(256)]
+        public static long SafeMod(long x, long m)
+        {
+            x %= m;
+            if (x < 0) x += m;
+            return x;
+        }
+
+        /// <summary>
+        /// <paramref name="x"/>^<paramref name="n"/> mod <paramref name="m"/> を返します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: 0≤<paramref name="n"/>, 1≤<paramref name="m"/></para>
+        /// <para>計算量: O(log<paramref name="n"/>)</para>
+        /// </remarks>
+        [MethodImpl(256)]
+        public static uint PowMod(long x, long n, int m)
+        {
+            Contract.Assert(0 <= n && 1 <= m, reason: $"0 <= {nameof(n)} && 1 <= {nameof(m)}");
+            if (m == 1) return 0;
+            return new Barrett((uint)m).Pow(x, n);
+        }
+
+        /// <summary>
+        /// 同じ長さ n の配列 <paramref name="r"/>, <paramref name="m"/> について、x≡<paramref name="r"/>[i] (mod <paramref name="m"/>[i]),∀i∈{0,1,⋯,n−1} を解きます。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: |<paramref name="r"/>|=|<paramref name="m"/>|, 1≤<paramref name="m"/>[i], lcm(m[i]) が ll に収まる</para>
+        /// <para>計算量: O(nloglcm(<paramref name="m"/>))</para>
+        /// </remarks>
+        /// <returns>答えは(存在するならば) y,z(0≤y&lt;z=lcm(<paramref name="m"/>[i])) を用いて x≡y(mod z) の形で書ける。答えがない場合は(0,0)、n=0 の時は(0,1)、それ以外の場合は(y,z)。</returns>
+        [MethodImpl(256)]
+        public static (long y, long z) Crt(long[] r, long[] m)
+        {
+            Contract.Assert(r.Length == m.Length, reason: $"Length of {nameof(r)} and {nameof(m)} must be same.");
+
+            long r0 = 0, m0 = 1;
+            for (int i = 0; i < m.Length; i++)
+            {
+                Contract.Assert(1 <= m[i], reason: $"All of {nameof(m)} must be greater or equal 1.");
+                long r1 = SafeMod(r[i], m[i]);
+                long m1 = m[i];
+                if (m0 < m1)
+                {
+                    (r0, r1) = (r1, r0);
+                    (m0, m1) = (m1, m0);
+                }
+                if (m0 % m1 == 0)
+                {
+                    if (r0 % m1 != r1) return (0, 0);
+                    continue;
+                }
+                var (g, im) = InvGcd(m0, m1);
+
+                long u1 = (m1 / g);
+                if ((r1 - r0) % g != 0) return (0, 0);
+
+                long x = (r1 - r0) / g % u1 * im % u1;
+                r0 += x * m0;
+                m0 *= u1;
+                if (r0 < 0) r0 += m0;
+            }
+            return (r0, m0);
+        }
+    }
+}

--- a/Source/ac-library-csharp/Math/Internal/ModPrimitiveRoot.cs
+++ b/Source/ac-library-csharp/Math/Internal/ModPrimitiveRoot.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Numerics;
+#endif
+#if NET7_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
+
+namespace AtCoder.Internal
+{
+    public static class ModPrimitiveRoot
+    {
+        private static readonly Dictionary<uint, int> primitiveRootsCache = new Dictionary<uint, int>()
+        {
+            { 2, 1 },
+            { 167772161, 3 },
+            { 469762049, 3 },
+            { 754974721, 11 },
+            { 998244353, 3 }
+        };
+
+        /// <summary>
+        /// <typeparamref name="TMod"/> の最小の原始根を求めます。
+        /// </summary>
+        /// <remarks>
+        /// 制約: <typeparamref name="TMod"/> は素数
+        /// </remarks>
+        [MethodImpl(256)]
+        public static int PrimitiveRoot<TMod>() where TMod : struct, IStaticMod
+        {
+            uint m = default(TMod).Mod;
+            Contract.Assert(m >= 2, reason: $"{nameof(m)} must be greater or equal 2");
+            Contract.Assert(default(TMod).IsPrime, reason: $"{nameof(m)} must be prime number");
+
+#if NET7_0_OR_GREATER
+            ref var result = ref CollectionsMarshal.GetValueRefOrAddDefault(primitiveRootsCache, m, out var exists);
+            if (!exists)
+            {
+                result = PrimitiveRootCalculate<TMod>();
+            }
+            return result;
+#else
+            if (primitiveRootsCache.TryGetValue(m, out var p))
+            {
+                return p;
+            }
+
+            return primitiveRootsCache[m] = PrimitiveRootCalculate<TMod>();
+#endif
+        }
+        static int PrimitiveRootCalculate<TMod>() where TMod : struct, IStaticMod
+        {
+            var m = default(TMod).Mod;
+            Span<uint> divs = stackalloc uint[20];
+            divs[0] = 2;
+            int cnt = 1;
+            var x = m - 1;
+            x >>= BitOperations.TrailingZeroCount(x);
+
+            for (uint i = 3; (long)i * i <= x; i += 2)
+            {
+                if (x % i == 0)
+                {
+                    divs[cnt++] = i;
+                    do
+                    {
+                        x /= i;
+                    } while (x % i == 0);
+                }
+            }
+
+            if (x > 1)
+            {
+                divs[cnt++] = x;
+            }
+            divs = divs.Slice(0, cnt);
+
+            for (int g = 2; ; g++)
+            {
+                foreach (var d in divs)
+                    if (new StaticModInt<TMod>(g).Pow((m - 1) / d).Value == 1)
+                        goto NEXT;
+                return g;
+            NEXT:;
+            }
+        }
+    }
+}

--- a/Source/ac-library-csharp/Math/MathLib.Convolution.cs
+++ b/Source/ac-library-csharp/Math/MathLib.Convolution.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using AtCoder.Internal;
 
@@ -37,69 +36,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public static StaticModInt<TMod>[] Convolution<TMod>(ReadOnlySpan<StaticModInt<TMod>> a, ReadOnlySpan<StaticModInt<TMod>> b)
             where TMod : struct, IStaticMod
-        {
-            var n = a.Length;
-            var m = b.Length;
-            if (n == 0 || m == 0)
-                return Array.Empty<StaticModInt<TMod>>();
-            if (Math.Min(n, m) <= 60)
-                return ConvolutionNaive(a, b);
-            return ConvolutionFFT(a, b);
-        }
-
-        [MethodImpl(256)]
-        private static StaticModInt<TMod>[] ConvolutionFFT<TMod>(ReadOnlySpan<StaticModInt<TMod>> a, ReadOnlySpan<StaticModInt<TMod>> b)
-            where TMod : struct, IStaticMod
-        {
-            int n = a.Length, m = b.Length;
-            int z = 1 << InternalBit.CeilPow2(n + m - 1);
-            var a2 = new StaticModInt<TMod>[z];
-            var b2 = new StaticModInt<TMod>[z];
-            a.CopyTo(a2);
-            b.CopyTo(b2);
-
-            var result = ConvolutionFFTInner(a2, b2);
-            Array.Resize(ref result, n + m - 1);
-            var iz = new StaticModInt<TMod>(z).Inv();
-            for (int i = 0; i < result.Length; i++)
-                result[i] *= iz;
-
-            return result;
-        }
-
-        [MethodImpl(256)]
-        private static StaticModInt<TMod>[] ConvolutionFFTInner<TMod>(StaticModInt<TMod>[] a, StaticModInt<TMod>[] b)
-            where TMod : struct, IStaticMod
-        {
-            Butterfly<TMod>.Calculate(a);
-            Butterfly<TMod>.Calculate(b);
-            for (int i = 0; i < a.Length; i++)
-                a[i] *= b[i];
-            Butterfly<TMod>.CalculateInv(a);
-            return a;
-        }
-        [MethodImpl(256)]
-        private static StaticModInt<TMod>[] ConvolutionNaive<TMod>(ReadOnlySpan<StaticModInt<TMod>> a, ReadOnlySpan<StaticModInt<TMod>> b)
-            where TMod : struct, IStaticMod
-        {
-            if (a.Length < b.Length)
-            {
-                var temp = a;
-                a = b;
-                b = temp;
-            }
-
-            var ans = new StaticModInt<TMod>[a.Length + b.Length - 1];
-            for (int i = 0; i < a.Length; i++)
-            {
-                for (int j = 0; j < b.Length; j++)
-                {
-                    ans[i + j] += a[i] * b[j];
-                }
-            }
-
-            return ans;
-        }
+            => ConvolutionImpl.Convolution(a, b);
 
         /// <summary>
         /// 畳み込みを計算します。
@@ -113,100 +50,6 @@ namespace AtCoder
         /// </remarks>
         [MethodImpl(256)]
         public static long[] ConvolutionLong(ReadOnlySpan<long> a, ReadOnlySpan<long> b)
-        {
-            unchecked
-            {
-                var n = a.Length;
-                var m = b.Length;
-
-                if (n == 0 || m == 0)
-                {
-                    return Array.Empty<long>();
-                }
-
-                const ulong Mod1 = 754974721;  // 2^24
-                const ulong Mod2 = 167772161;  // 2^25
-                const ulong Mod3 = 469762049;  // 2^26
-                const ulong M2M3 = Mod2 * Mod3;
-                const ulong M1M3 = Mod1 * Mod3;
-                const ulong M1M2 = Mod1 * Mod2;
-                // (m1 * m2 * m3) % 2^64
-                const ulong M1M2M3 = Mod1 * Mod2 * Mod3;
-
-                const ulong i1 = 190329765;
-                const ulong i2 = 58587104;
-                const ulong i3 = 187290749;
-
-                Debug.Assert(default(FFTMod1).Mod == Mod1);
-                Debug.Assert(default(FFTMod2).Mod == Mod2);
-                Debug.Assert(default(FFTMod3).Mod == Mod3);
-                Debug.Assert(i1 == (ulong)ModCalc.InvGcd((long)M2M3, (long)Mod1).Item2);
-                Debug.Assert(i2 == (ulong)ModCalc.InvGcd((long)M1M3, (long)Mod2).Item2);
-                Debug.Assert(i3 == (ulong)ModCalc.InvGcd((long)M1M2, (long)Mod3).Item2);
-
-                var c1 = Convolution<FFTMod1>(a, b);
-                var c2 = Convolution<FFTMod2>(a, b);
-                var c3 = Convolution<FFTMod3>(a, b);
-
-                var c = new long[n + m - 1];
-
-                //ReadOnlySpan<ulong> offset = stackalloc ulong[] { 0, 0, M1M2M3, 2 * M1M2M3, 3 * M1M2M3 };
-
-                for (int i = 0; i < c.Length; i++)
-                {
-                    ulong x = 0;
-                    x += ((ulong)c1[i] * i1) % Mod1 * M2M3;
-                    x += ((ulong)c2[i] * i2) % Mod2 * M1M3;
-                    x += ((ulong)c3[i] * i3) % Mod3 * M1M2;
-
-                    long diff = c1[i] - ModCalc.SafeMod((long)x, (long)Mod1);
-                    if (diff < 0)
-                    {
-                        diff += (long)Mod1;
-                    }
-
-                    // 真値を r, 得られた値を x, M1M2M3 % 2^64 = M', B = 2^63 として、
-                    // r = x,
-                    //     x -  M' + (0 or 2B),
-                    //     x - 2M' + (0 or 2B or 4B),
-                    //     x - 3M' + (0 or 2B or 4B or 6B)
-                    // のいずれかが成り立つ、らしい
-                    // -> see atcoder/convolution.hpp
-                    switch (diff % 5)
-                    {
-                        case 2:
-                            x -= M1M2M3;
-                            break;
-                        case 3:
-                            x -= 2 * M1M2M3;
-                            break;
-                        case 4:
-                            x -= 3 * M1M2M3;
-                            break;
-                    }
-                    c[i] = (long)x;
-                }
-
-                return c;
-            }
-        }
-
-        private readonly struct FFTMod1 : IStaticMod
-        {
-            public uint Mod => 754974721;
-            public bool IsPrime => true;
-        }
-
-        private readonly struct FFTMod2 : IStaticMod
-        {
-            public uint Mod => 167772161;
-            public bool IsPrime => true;
-        }
-
-        private readonly struct FFTMod3 : IStaticMod
-        {
-            public uint Mod => 469762049;
-            public bool IsPrime => true;
-        }
+            => ConvolutionImpl.ConvolutionLong(a, b);
     }
 }

--- a/Source/ac-library-csharp/Math/MathLib.Convolution.cs
+++ b/Source/ac-library-csharp/Math/MathLib.Convolution.cs
@@ -84,11 +84,9 @@ namespace AtCoder
         {
             if (a.Length < b.Length)
             {
-#pragma warning disable IDE0180 // ref 構造体のため型引数として使えない
                 var temp = a;
                 a = b;
                 b = temp;
-#pragma warning restore IDE0180
             }
 
             var ans = new StaticModInt<TMod>[a.Length + b.Length - 1];
@@ -142,9 +140,9 @@ namespace AtCoder
                 Debug.Assert(default(FFTMod1).Mod == Mod1);
                 Debug.Assert(default(FFTMod2).Mod == Mod2);
                 Debug.Assert(default(FFTMod3).Mod == Mod3);
-                Debug.Assert(i1 == (ulong)InternalMath.InvGcd((long)M2M3, (long)Mod1).Item2);
-                Debug.Assert(i2 == (ulong)InternalMath.InvGcd((long)M1M3, (long)Mod2).Item2);
-                Debug.Assert(i3 == (ulong)InternalMath.InvGcd((long)M1M2, (long)Mod3).Item2);
+                Debug.Assert(i1 == (ulong)ModCalc.InvGcd((long)M2M3, (long)Mod1).Item2);
+                Debug.Assert(i2 == (ulong)ModCalc.InvGcd((long)M1M3, (long)Mod2).Item2);
+                Debug.Assert(i3 == (ulong)ModCalc.InvGcd((long)M1M2, (long)Mod3).Item2);
 
                 var c1 = Convolution<FFTMod1>(a, b);
                 var c2 = Convolution<FFTMod2>(a, b);
@@ -161,7 +159,7 @@ namespace AtCoder
                     x += ((ulong)c2[i] * i2) % Mod2 * M1M3;
                     x += ((ulong)c3[i] * i3) % Mod3 * M1M2;
 
-                    long diff = c1[i] - InternalMath.SafeMod((long)x, (long)Mod1);
+                    long diff = c1[i] - ModCalc.SafeMod((long)x, (long)Mod1);
                     if (diff < 0)
                     {
                         diff += (long)Mod1;

--- a/Source/ac-library-csharp/Math/MathLib.Crt.cs
+++ b/Source/ac-library-csharp/Math/MathLib.Crt.cs
@@ -5,46 +5,9 @@ namespace AtCoder
 {
     public static partial class MathLib
     {
-        /// <summary>
-        /// 同じ長さ n の配列 <paramref name="r"/>, <paramref name="m"/> について、x≡<paramref name="r"/>[i] (mod <paramref name="m"/>[i]),∀i∈{0,1,⋯,n−1} を解きます。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: |<paramref name="r"/>|=|<paramref name="m"/>|, 1≤<paramref name="m"/>[i], lcm(m[i]) が ll に収まる</para>
-        /// <para>計算量: O(nloglcm(<paramref name="m"/>))</para>
-        /// </remarks>
-        /// <returns>答えは(存在するならば) y,z(0≤y&lt;z=lcm(<paramref name="m"/>[i])) を用いて x≡y(mod z) の形で書ける。答えがない場合は(0,0)、n=0 の時は(0,1)、それ以外の場合は(y,z)。</returns>
+        /// <inheritdoc cref="ModCalc.Crt(long[], long[])" />
         [MethodImpl(256)]
         public static (long y, long z) Crt(long[] r, long[] m)
-        {
-            Contract.Assert(r.Length == m.Length, reason: $"Length of {nameof(r)} and {nameof(m)} must be same.");
-
-            long r0 = 0, m0 = 1;
-            for (int i = 0; i < m.Length; i++)
-            {
-                Contract.Assert(1 <= m[i], reason: $"All of {nameof(m)} must be greater or equal 1.");
-                long r1 = InternalMath.SafeMod(r[i], m[i]);
-                long m1 = m[i];
-                if (m0 < m1)
-                {
-                    (r0, r1) = (r1, r0);
-                    (m0, m1) = (m1, m0);
-                }
-                if (m0 % m1 == 0)
-                {
-                    if (r0 % m1 != r1) return (0, 0);
-                    continue;
-                }
-                var (g, im) = InternalMath.InvGcd(m0, m1);
-
-                long u1 = (m1 / g);
-                if ((r1 - r0) % g != 0) return (0, 0);
-
-                long x = (r1 - r0) / g % u1 * im % u1;
-                r0 += x * m0;
-                m0 *= u1;
-                if (r0 < 0) r0 += m0;
-            }
-            return (r0, m0);
-        }
+            => ModCalc.Crt(r, m);
     }
 }

--- a/Source/ac-library-csharp/Math/MathLib.FloorSum.cs
+++ b/Source/ac-library-csharp/Math/MathLib.FloorSum.cs
@@ -1,45 +1,12 @@
 ﻿using System.Runtime.CompilerServices;
-using AtCoder.Internal;
 
 namespace AtCoder
 {
     public static partial class MathLib
     {
-        /// <summary>
-        /// sum_{i=0}^{<paramref name="n"/>-1} floor(<paramref name="a"/>*i+<paramref name="b"/>/<paramref name="m"/>) を返します。答えがオーバーフローしたならば  mod2^64 で等しい値を返します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約:</para>
-        /// <para> 0≤<paramref name="n"/>&lt;2^32</para>
-        /// <para> 1≤<paramref name="m"/>&lt;2^32</para>
-        /// <para>計算量: O(log(m))</para>
-        /// </remarks>
-        /// <returns></returns>
+        /// <inheritdoc cref="Internal.FloorSum.FloorSumSigned(long, long, long, long)" />
         [MethodImpl(256)]
         public static long FloorSum(long n, long m, long a, long b)
-        {
-            Contract.Assert(0 <= n && n < (1L << 32));
-            Contract.Assert(1 <= m && m < (1L << 32));
-            var nn = (ulong)n;
-            var mm = (ulong)m;
-            ulong aa, bb;
-            ulong ans = 0;
-            if (a < 0)
-            {
-                var a2 = (ulong)InternalMath.SafeMod(a, m);
-                ans -= nn * (nn - 1) / 2 * ((a2 - (ulong)a) / mm);
-                aa = a2;
-            }
-            else aa = (ulong)a;
-            if (b < 0)
-            {
-                var b2 = (ulong)InternalMath.SafeMod(b, m);
-                ans -= nn * ((b2 - (ulong)b) / mm);
-                bb = b2;
-            }
-            else bb = (ulong)b;
-
-            return (long)(ans + InternalMath.FloorSumUnsigned(nn, mm, aa, bb));
-        }
+            => Internal.FloorSum.FloorSumSigned(n, m, a, b);
     }
 }

--- a/Source/ac-library-csharp/Math/MathLib.InvMod.cs
+++ b/Source/ac-library-csharp/Math/MathLib.InvMod.cs
@@ -5,20 +5,9 @@ namespace AtCoder
 {
     public static partial class MathLib
     {
-        /// <summary>
-        /// <paramref name="x"/>y≡1(mod <paramref name="m"/>) なる y のうち、0≤y&lt;<paramref name="m"/> を満たすものを返します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: gcd(<paramref name="x"/>,<paramref name="m"/>)=1, 1≤<paramref name="m"/></para>
-        /// <para>計算量: O(log<paramref name="m"/>)</para>
-        /// </remarks>
+        /// <inheritdoc cref="ModCalc.InvMod(long, long)" />
         [MethodImpl(256)]
         public static long InvMod(long x, long m)
-        {
-            Contract.Assert(1 <= m, reason: $"1 <= {nameof(m)}");
-            var (g, res) = InternalMath.InvGcd(x, m);
-            Contract.Assert(g == 1, reason: $"gcd({nameof(x)}, {nameof(m)}) must be 1.");
-            return res;
-        }
+            => ModCalc.InvMod(x, m);
     }
 }

--- a/Source/ac-library-csharp/Math/MathLib.PowMod.cs
+++ b/Source/ac-library-csharp/Math/MathLib.PowMod.cs
@@ -5,15 +5,9 @@ namespace AtCoder
 {
     public static partial class MathLib
     {
-        /// <summary>
-        /// <paramref name="x"/>^<paramref name="n"/> mod <paramref name="m"/> を返します。
-        /// </summary>
-        /// <remarks>
-        /// <para>制約: 0≤<paramref name="n"/>, 1≤<paramref name="m"/></para>
-        /// <para>計算量: O(log<paramref name="n"/>)</para>
-        /// </remarks>
+        /// <inheritdoc cref="ModCalc.PowMod(long, long, int)" />
         [MethodImpl(256)]
         public static long PowMod(long x, long n, int m)
-            => InternalMath.PowMod(x, n, m);
+            => ModCalc.PowMod(x, n, m);
     }
 }

--- a/Source/ac-library-csharp/Math/ModInt/DynamicModInt.cs
+++ b/Source/ac-library-csharp/Math/ModInt/DynamicModInt.cs
@@ -102,7 +102,7 @@ namespace AtCoder
         /// <para>- <paramref name="v"/> が 0 未満、もしくは mod 以上の場合、自動で mod を取ります。</para>
         /// </remarks>
         [MethodImpl(256)]
-        public DynamicModInt(long v) : this((uint)InternalMath.SafeMod(v, bt.Mod)) { }
+        public DynamicModInt(long v) : this((uint)ModCalc.SafeMod(v, bt.Mod)) { }
 
         /// <summary>
         /// DynamicModInt&lt;<typeparamref name="T"/>&gt; 型のインスタンスを生成します。
@@ -228,7 +228,7 @@ namespace AtCoder
         [MethodImpl(256)]
         public DynamicModInt<T> Inv()
         {
-            var (g, x) = InternalMath.InvGcd(_v, bt.Mod);
+            var (g, x) = ModCalc.InvGcd(_v, bt.Mod);
             Contract.Assert(g == 1, reason: $"gcd({nameof(x)}, {nameof(Mod)}) must be 1.");
             return new DynamicModInt<T>(x);
         }

--- a/Source/ac-library-csharp/Math/ModInt/StaticModInt.cs
+++ b/Source/ac-library-csharp/Math/ModInt/StaticModInt.cs
@@ -66,7 +66,7 @@ namespace AtCoder
         /// <paramref name="v"/>が 0 未満、もしくは mod 以上の場合、自動で mod を取ります。
         /// </remarks>
         [MethodImpl(256)]
-        public StaticModInt(long v) : this((uint)InternalMath.SafeMod(v, op.Mod)) { }
+        public StaticModInt(long v) : this((uint)ModCalc.SafeMod(v, op.Mod)) { }
 
         /// <summary>
         /// StaticModInt&lt;<typeparamref name="T"/>&gt; 型のインスタンスを生成します。
@@ -211,7 +211,7 @@ namespace AtCoder
             }
             else
             {
-                var (g, x) = InternalMath.InvGcd(_v, op.Mod);
+                var (g, x) = ModCalc.InvGcd(_v, op.Mod);
                 Contract.Assert(g == 1, reason: $"gcd({nameof(x)}, {nameof(Mod)}) must be 1.");
                 return new StaticModInt<T>(x);
             }

--- a/Test/ac-library-csharp.Test/Internal/InternalMathTest.cs
+++ b/Test/ac-library-csharp.Test/Internal/InternalMathTest.cs
@@ -198,7 +198,8 @@ namespace AtCoder.Internal
                     var x = a + (ulong)i;
                     var y = b + (ulong)j;
                     ulong expected = Math.BigMul(x, y, out _);
-                    InternalMath.Mul128BitLogic(x, y).Should().Be(expected);
+                    InternalMath.Mul128Bit(x, y).Should().Be(expected);
+                    BigMul.Mul128Bit(x, y).Should().Be(expected);
                 }
         }
         [Fact]
@@ -212,7 +213,7 @@ namespace AtCoder.Internal
                 var x = arr[0];
                 var y = arr[1];
                 ulong expected = Math.BigMul(x, y, out _);
-                InternalMath.Mul128BitLogic(x, y).Should().Be(expected);
+                BigMul.Mul128BitLogic(x, y).Should().Be(expected);
             }
         }
 #endif


### PR DESCRIPTION
`MathLib` の一部を使うだけでも `MathLib` 全体に依存していることになるので、中国剰余定理を使うだけで畳み込みまでが SourceExpander に含まれてしまう。

実装を分離して `MathLib` と `InternalMath` は実装を呼び出すだけにした。